### PR TITLE
Update gmAuthWidgets.py: very small fix!

### DIFF
--- a/gnumed/gnumed/client/wxpython/gmAuthWidgets.py
+++ b/gnumed/gnumed/client/wxpython/gmAuthWidgets.py
@@ -638,7 +638,7 @@ class cLoginPanel(wx.Panel):
 	#----------------------------------------------------------
 	def __set_label_color(self, label):
 		"""Set adaptive label color based on system theme background."""
-		if gmGuiHelpers.is_probably_dark_theme():
+		if not gmGuiHelpers.is_probably_dark_theme():
 			label.SetForegroundColour(wx.Colour(35, 35, 142))  # orig dark blue
 
 	#----------------------------------------------------


### PR DESCRIPTION
- before: if dark theme it set TEXT login color to dark blue
- now: if NOT dark theme, text login color dark blue (w/ light background)
- just added "not"