### PR TITLE
Fix bootstrap failure when importing hyphenated data scripts

### DIFF
--- a/gnumed/gnumed/client/pycommon/gmTools.py
+++ b/gnumed/gnumed/client/pycommon/gmTools.py
@@ -1149,35 +1149,37 @@ def import_module_from_directory(module_path=None, module_name=None, always_remo
 	if module_name_raw == module_name:
 		module_file = '%s.py' % module_file
 
+	def _raise_import_error(cause):
+		msg = 'cannot __import__() module [%s] from [%s]' % (module_name, module_path)
+		_log.exception(msg)
+		raise ImportError(msg) from cause
+
 	try:
-		#module = __import__(module_name)
-		module = importlib.import_module(module_name)
-		if module_name not in sys.modules:
-			sys.modules[module_name] = module
-	except Exception:
-		if not os.path.exists(module_file):
-			_log.exception('cannot __import__() module [%s] from [%s]' % (module_name, module_path))
-			while module_path in sys.path:
-				sys.path.remove(module_path)
-			raise
-
 		try:
-			spec = importlib.util.spec_from_file_location(module_name, module_file)
-			module = importlib.util.module_from_spec(spec)
-			sys.modules[module_name] = module
-			spec.loader.exec_module(module)
-		except Exception:
-			_log.exception('cannot __import__() module [%s] from [%s]' % (module_name, module_path))
+			#module = __import__(module_name)
+			module = importlib.import_module(module_name)
+			if module_name not in sys.modules:
+				sys.modules[module_name] = module
+		except Exception as first_error:
+			if not os.path.exists(module_file):
+				_raise_import_error(first_error)
+
+			try:
+				spec = importlib.util.spec_from_file_location(module_name, module_file)
+				if spec is None or spec.loader is None:
+					raise ImportError('unable to build import spec for [%s]' % module_file)
+				module = importlib.util.module_from_spec(spec)
+				sys.modules[module_name] = module
+				spec.loader.exec_module(module)
+			except Exception as second_error:
+				_raise_import_error(second_error)
+
+		_log.info('imported module [%s] as [%s]' % (module_name, module))
+		return module
+	finally:
+		if remove_path:
 			while module_path in sys.path:
 				sys.path.remove(module_path)
-			raise
-
-	_log.info('imported module [%s] as [%s]' % (module_name, module))
-	if remove_path:
-		while module_path in sys.path:
-			sys.path.remove(module_path)
-
-	return module
 
 #===========================================================================
 # text related tools

--- a/gnumed/gnumed/client/pycommon/gmTools.py
+++ b/gnumed/gnumed/client/pycommon/gmTools.py
@@ -22,6 +22,7 @@ import json
 import shutil
 import zipfile
 import importlib
+import importlib.util
 import datetime as pydt
 import re as regex
 import xml.sax.saxutils as xml_tools
@@ -1140,17 +1141,36 @@ def import_module_from_directory(module_path=None, module_name=None, always_remo
 
 	_log.debug('will remove import path: %s', remove_path)
 
+	module_name_raw = module_name
 	if module_name.endswith('.py'):
 		module_name = module_name[:-3]
+
+	module_file = os.path.join(module_path, module_name_raw)
+	if module_name_raw == module_name:
+		module_file = '%s.py' % module_file
 
 	try:
 		#module = __import__(module_name)
 		module = importlib.import_module(module_name)
+		if module_name not in sys.modules:
+			sys.modules[module_name] = module
 	except Exception:
-		_log.exception('cannot __import__() module [%s] from [%s]' % (module_name, module_path))
-		while module_path in sys.path:
-			sys.path.remove(module_path)
-		raise
+		if not os.path.exists(module_file):
+			_log.exception('cannot __import__() module [%s] from [%s]' % (module_name, module_path))
+			while module_path in sys.path:
+				sys.path.remove(module_path)
+			raise
+
+		try:
+			spec = importlib.util.spec_from_file_location(module_name, module_file)
+			module = importlib.util.module_from_spec(spec)
+			sys.modules[module_name] = module
+			spec.loader.exec_module(module)
+		except Exception:
+			_log.exception('cannot __import__() module [%s] from [%s]' % (module_name, module_path))
+			while module_path in sys.path:
+				sys.path.remove(module_path)
+			raise
 
 	_log.info('imported module [%s] as [%s]' % (module_name, module))
 	if remove_path:


### PR DESCRIPTION
### Motivation
- Bootstrapping failed when loading data-import scripts such as `import-form-templates.py` because the dynamic loader treated script names as Python module identifiers and `importlib.import_module()` cannot handle hyphens. 
- The goal is to allow bootstrap to import script files from arbitrary paths and filenames used in upgrade configs without requiring renaming.

### Description
- Enhanced `import_module_from_directory()` to detect script filenames and compute the actual file path (`module_file`) from the provided `module_path` and `module_name`.
- Retained the existing `importlib.import_module()` path and added a fallback to load the file directly via `importlib.util.spec_from_file_location()` when the initial import fails or the module name contains characters unsupported by standard imports.
- Ensure fallback-loaded modules are registered in `sys.modules` under the script-derived name so existing cleanup logic that deletes `sys.modules[...]` continues to work.
- Kept the logic that temporarily appends the script directory to `sys.path` and removes it afterward to preserve existing behavior.

### Testing
- Ran syntax check via `python3 -m py_compile gnumed/gnumed/client/pycommon/gmTools.py` which succeeded.
- Executed an isolated automated snippet using `importlib.util.spec_from_file_location()` to verify that hyphenated filenames can be loaded; that test succeeded.
- Attempted to exercise `gmTools.import_module_from_directory()` in-tree, but the runtime check that imports `Gnumed` failed in this execution environment with `ModuleNotFoundError: No module named 'Gnumed'`, so full end-to-end runtime validation using the project package could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964f73c3f4832196a5c358c2d0f460)