### PR TITLE
Add missing argument to types.MethodType() call

### DIFF
--- a/gnumed/gnumed/client/pycommon/gmConnectionPool.py
+++ b/gnumed/gnumed/client/pycommon/gmConnectionPool.py
@@ -861,7 +861,7 @@ class gmConnectionPool(gmBorg.cBorg):
 		if readonly and pooled:
 			# monkey patch close() for pooled RO connections
 			conn.original_close = conn.close											# type: ignore [attr-defined]
-			conn.close = types.MethodType(_raise_exception_on_pooled_ro_conn_close)		# typeXX: ignore [assignment]
+			conn.close = types.MethodType(_raise_exception_on_pooled_ro_conn_close, conn)		# typeXX: ignore [assignment]
 		# set connection properties
 		# - client encoding
 		encoding = 'UTF8'


### PR DESCRIPTION
Hi!

Updated local branch to latest upstream master, types.MethodType() was missing its second argument, resulting in GNUmed crashing just after log in attempt, showing the following unhandled exception:

2026-03-26 13:28:57  DEBUG     gm.gui        [140629379485952 MainThread]  (/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmExceptionHandlingWidgets.py::handle_uncaught_exception_wx() #201): unhandled exception caught:
Traceback (most recent call last):
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmGuiMain.py", line 3494, in OnInit
    if not self.__establish_backend_connection():
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmGuiMain.py", line 3770, in __establish_backend_connection
    connected = gmAuthWidgets.connect_to_database (
    	expected_version = gmPG2.map_client_branch2required_db_version[_cfg.get(option = 'client_branch')],
    	require_version = not override
    )
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmAuthWidgets.py", line 280, in connect_to_database
    if not __database_is_acceptable_for_use(require_version = require_version, expected_version = expected_version, login = login):
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/wxpython/gmAuthWidgets.py", line 169, in __database_is_acceptable_for_use
    if not gmPG2.schema_exists(schema = 'gm'):
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/pycommon/gmPG2.py", line 1030, in schema_exists
    rows = run_ro_queries(link_obj = link_obj, queries = [{'sql': cmd, 'args': args}])
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/pycommon/gmPG2.py", line 2416, in run_ro_queries
    conn = get_connection(readonly = True, verbose = verbose)
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/pycommon/gmPG2.py", line 2710, in get_connection
    return gmConnectionPool.gmConnectionPool().get_connection (
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
    	readonly = readonly,
     ^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    	pooled = pooled
     ^^^^^^^^^^^^^^^
    )
    ^
  File "/home/jessie/Documents/Informática/codes/gnumed_github/gnumed/gnumed/Gnumed/pycommon/gmConnectionPool.py", line 864, in get_connection
    conn.close = types.MethodType(_raise_exception_on_pooled_ro_conn_close)		# typeXX: ignore [assignment]
                 ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: method expected 2 arguments, got 1



Full log attached.
[gm-vcs-03_26--13_28_55--13201_types.MethodType()_crash.log](https://github.com/user-attachments/files/26282848/gm-vcs-03_26--13_28_55--13201_types.MethodType._crash.log)

Following the bug's trail, added the missing second argument, 'conn', just like types.MethodType() use at line 927... Tested on trixie.

María